### PR TITLE
feat: add biocfilecache-backed persistent caching

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: AnnotationGx
 Title: AnnotationGx: A package for building, updating and querying an
     annotation database for pharmaco-genomic data
-Version: 0.99.6
+Version: 0.99.7
 Authors@R: c(
     person("Michael", "Tran", role = c("aut"),
         email = "michaelcao-anh.tran@uhn.ca"),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: AnnotationGx
 Title: AnnotationGx: A package for building, updating and querying an
     annotation database for pharmaco-genomic data
-Version: 0.99.5
+Version: 0.99.6
 Authors@R: c(
     person("Michael", "Tran", role = c("aut"),
         email = "michaelcao-anh.tran@uhn.ca"),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -20,6 +20,7 @@ Description: A package for building, updating and querying an
 Depends: 
     R (>= 4.6.0)
 Imports: 
+    BiocFileCache,
     checkmate,
     crayon,
     httr2,

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,3 @@
 # Changes in version 0.99.7
 
-- Add persistent caching with `BiocFileCache` for remote metadata and parsed
-  API query results.
-- Isolate package tests in a temporary AnnotationGx cache directory.
+- Add persistent caching with `BiocFileCache` for remote metadata and parsed API query results.

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,5 @@
-# Changes in version 0.99.6
+# Changes in version 0.99.7
 
-- Initial Bioconductor Release
+- Add persistent caching with `BiocFileCache` for remote metadata and parsed
+  API query results.
+- Isolate package tests in a temporary AnnotationGx cache directory.

--- a/R/biomart_core.R
+++ b/R/biomart_core.R
@@ -40,14 +40,16 @@ MartInfo <- R6::R6Class(
     #' @param meta List, additional metadata
     #' @param group Character, the group the mart belongs to
     #' @return A new MartInfo object
-    initialize = function(name,
-                          displayName,
-                          description,
-                          config,
-                          isHidden,
-                          operation,
-                          meta,
-                          group) {
+    initialize = function(
+      name,
+      displayName,
+      description,
+      config,
+      isHidden,
+      operation,
+      meta,
+      group
+    ) {
       self$name <- name
       self$displayName <- displayName
       self$description <- description
@@ -163,12 +165,14 @@ FilterInfo <- R6::R6Class(
     #' @param isHidden Logical, whether the filter should be hidden in UIs
     #' @param values List or vector, possible values for the filter if applicable
     #' @return A new FilterInfo object
-    initialize = function(name,
-                          displayName = NULL,
-                          description = NULL,
-                          type = NULL,
-                          isHidden = NULL,
-                          values = NULL) {
+    initialize = function(
+      name,
+      displayName = NULL,
+      description = NULL,
+      type = NULL,
+      isHidden = NULL,
+      values = NULL
+    ) {
       self$name <- name
       self$displayName <- displayName
       self$description <- description
@@ -226,11 +230,13 @@ AttributeInfo <- R6::R6Class(
     #' @param linkURL Character, URL for additional information about the attribute
     #' @param isHidden Logical, whether the attribute should be hidden in UIs
     #' @return A new AttributeInfo object
-    initialize = function(name,
-                          displayName = NULL,
-                          description = NULL,
-                          linkURL = NULL,
-                          isHidden = NULL) {
+    initialize = function(
+      name,
+      displayName = NULL,
+      description = NULL,
+      linkURL = NULL,
+      isHidden = NULL
+    ) {
       self$name <- name
       self$displayName <- displayName
       self$description <- description
@@ -381,9 +387,18 @@ BioMartClient <- R6::R6Class(
       step <- cli::cli_progress_step("[Fetch] Fetching available marts")
       on.exit(cli::cli_progress_done(step), add = TRUE)
 
-      res <- private$.request("marts.json") |>
-        httr2::req_perform() |>
-        httr2::resp_body_json()
+      res <- .cache_fetch(
+        namespace = "biomart/marts",
+        params = list(
+          base_url = self$base_url,
+          path = self$path
+        ),
+        FUN = function() {
+          private$.request("marts.json") |>
+            httr2::req_perform() |>
+            httr2::resp_body_json()
+        }
+      )
 
       lapply(res, function(mart) {
         do.call(MartInfo$new, mart)
@@ -402,10 +417,20 @@ BioMartClient <- R6::R6Class(
       )
       on.exit(cli::cli_progress_done(step), add = TRUE)
 
-      res <- private$.request("datasets.json") |>
-        httr2::req_url_query(config = mart$config) |>
-        httr2::req_perform() |>
-        httr2::resp_body_json()
+      res <- .cache_fetch(
+        namespace = "biomart/datasets",
+        params = list(
+          base_url = self$base_url,
+          path = self$path,
+          config = mart$config
+        ),
+        FUN = function() {
+          private$.request("datasets.json") |>
+            httr2::req_url_query(config = mart$config) |>
+            httr2::req_perform() |>
+            httr2::resp_body_json()
+        }
+      )
 
       lapply(res, function(d) {
         DatasetInfo$new(
@@ -429,13 +454,24 @@ BioMartClient <- R6::R6Class(
       )
       on.exit(cli::cli_progress_done(step), add = TRUE)
 
-      res <- private$.request("attributes.json") |>
-        httr2::req_url_query(
-          datasets = dataset$name,
+      res <- .cache_fetch(
+        namespace = "biomart/attributes",
+        params = list(
+          base_url = self$base_url,
+          path = self$path,
+          dataset = dataset$name,
           config = dataset$mart$config
-        ) |>
-        httr2::req_perform() |>
-        httr2::resp_body_json()
+        ),
+        FUN = function() {
+          private$.request("attributes.json") |>
+            httr2::req_url_query(
+              datasets = dataset$name,
+              config = dataset$mart$config
+            ) |>
+            httr2::req_perform() |>
+            httr2::resp_body_json()
+        }
+      )
 
       attrs <- lapply(res, function(a) {
         AttributeInfo$new(
@@ -462,13 +498,24 @@ BioMartClient <- R6::R6Class(
       )
       on.exit(cli::cli_progress_done(step), add = TRUE)
 
-      res <- private$.request("filters.json") |>
-        httr2::req_url_query(
-          datasets = dataset$name,
+      res <- .cache_fetch(
+        namespace = "biomart/filters",
+        params = list(
+          base_url = self$base_url,
+          path = self$path,
+          dataset = dataset$name,
           config = dataset$mart$config
-        ) |>
-        httr2::req_perform() |>
-        httr2::resp_body_json()
+        ),
+        FUN = function() {
+          private$.request("filters.json") |>
+            httr2::req_url_query(
+              datasets = dataset$name,
+              config = dataset$mart$config
+            ) |>
+            httr2::req_perform() |>
+            httr2::resp_body_json()
+        }
+      )
 
       lapply(res, function(f) {
         FilterInfo$new(
@@ -648,104 +695,119 @@ query_hgnc_by_genes <- function(
 ) {
   stopifnot(is.character(genes), is.character(attributes))
 
-  client <- BioMartClient$new("https://biomart.genenames.org")
-  marts <- client$get_marts()
-  # TODO:: since this function is specific for genes,
-  # we shouldnt be allowing user to choose mart and dataset
-  # extract this selection to a separate function
-  # and make this function only for hgnc genes
-  # this way we can also maybe use something else?
+  query_impl <- function() {
+    client <- BioMartClient$new("https://biomart.genenames.org")
+    marts <- client$get_marts()
+    # TODO:: since this function is specific for genes,
+    # we shouldnt be allowing user to choose mart and dataset
+    # extract this selection to a separate function
+    # and make this function only for hgnc genes
+    # this way we can also maybe use something else?
 
-  # Select mart: either by name/displayName or default to first one
-  if (!is.null(mart_name)) {
-    mart_idx <- which(vapply(
-      marts,
-      function(m) {
-        m$name == mart_name || m$displayName == mart_name
-      },
-      FUN.VALUE = logical(1)
-    ))
-    if (length(mart_idx) == 0) {
-      available_marts <- vapply(
+    # Select mart: either by name/displayName or default to first one
+    if (!is.null(mart_name)) {
+      mart_idx <- which(vapply(
         marts,
         function(m) {
-          paste0(m$name, " (", m$displayName, ")")
+          m$name == mart_name || m$displayName == mart_name
         },
-        character(1)
-      )
-      stop(
-        "Invalid mart name: '",
-        mart_name,
-        "'. Available marts: ",
-        paste(available_marts, collapse = ", ")
-      )
+        FUN.VALUE = logical(1)
+      ))
+      if (length(mart_idx) == 0) {
+        available_marts <- vapply(
+          marts,
+          function(m) {
+            paste0(m$name, " (", m$displayName, ")")
+          },
+          character(1)
+        )
+        stop(
+          "Invalid mart name: '",
+          mart_name,
+          "'. Available marts: ",
+          paste(available_marts, collapse = ", ")
+        )
+      }
+      mart <- marts[[mart_idx[1]]]
+    } else {
+      mart <- marts[[1]]
     }
-    mart <- marts[[mart_idx[1]]]
-  } else {
-    mart <- marts[[1]]
-  }
 
-  datasets <- client$get_datasets(mart)
+    datasets <- client$get_datasets(mart)
 
-  # Select dataset: either by name/displayName or default to first one
-  if (!is.null(dataset_name)) {
-    dataset_idx <- which(vapply(
-      datasets,
-      function(d) {
-        d$name == dataset_name || d$displayName == dataset_name
-      },
-      FUN.VALUE = logical(1)
-    ))
-    if (length(dataset_idx) == 0) {
-      available_datasets <- vapply(
+    # Select dataset: either by name/displayName or default to first one
+    if (!is.null(dataset_name)) {
+      dataset_idx <- which(vapply(
         datasets,
         function(d) {
-          paste0(d$name, " (", d$displayName, ")")
+          d$name == dataset_name || d$displayName == dataset_name
         },
-        character(1)
-      )
-      stop(
-        "Invalid dataset name: '",
-        dataset_name,
-        "'. Available datasets: ",
-        paste(available_datasets, collapse = ", ")
-      )
+        FUN.VALUE = logical(1)
+      ))
+      if (length(dataset_idx) == 0) {
+        available_datasets <- vapply(
+          datasets,
+          function(d) {
+            paste0(d$name, " (", d$displayName, ")")
+          },
+          character(1)
+        )
+        stop(
+          "Invalid dataset name: '",
+          dataset_name,
+          "'. Available datasets: ",
+          paste(available_datasets, collapse = ", ")
+        )
+      }
+      dset <- datasets[[dataset_idx[1]]]
+    } else {
+      dset <- datasets[[1]]
     }
-    dset <- datasets[[dataset_idx[1]]]
-  } else {
-    dset <- datasets[[1]]
-  }
 
-  attrset <- client$get_attributes(dset)
+    attrset <- client$get_attributes(dset)
 
-  valid_attrs <- attrset$get_by_display_name(attributes)
-  if (length(valid_attrs$attributes) != length(attributes)) {
-    available <- vapply(attrset$attributes, \(a) a$displayName, character(1))
-    missing <- setdiff(attributes, available)
-    errmsg <- paste("Invalid attribute(s):", paste(missing, collapse = ", "))
-    # show valid attributes if available
-    if (length(available) > 0) {
-      errmsg <- paste(
-        errmsg,
-        "\nAvailable attributes:\n\t-",
-        paste(available, collapse = "\n\t- ")
-      )
+    valid_attrs <- attrset$get_by_display_name(attributes)
+    if (length(valid_attrs$attributes) != length(attributes)) {
+      available <- vapply(attrset$attributes, \(a) a$displayName, character(1))
+      missing <- setdiff(attributes, available)
+      errmsg <- paste("Invalid attribute(s):", paste(missing, collapse = ", "))
+      # show valid attributes if available
+      if (length(available) > 0) {
+        errmsg <- paste(
+          errmsg,
+          "\nAvailable attributes:\n\t-",
+          paste(available, collapse = "\n\t- ")
+        )
+      }
+      stop(errmsg)
     }
-    stop(errmsg)
-  }
 
-  q <- bm_query_builder(
-    dataset = dset,
-    attributes = valid_attrs,
-    filters = list(
-      hgnc_gene__approved_symbol_1010_text = paste(genes, collapse = ",")
+    q <- bm_query_builder(
+      dataset = dset,
+      attributes = valid_attrs,
+      filters = list(
+        hgnc_gene__approved_symbol_1010_text = paste(genes, collapse = ",")
+      )
     )
+
+    resp <- httr2::request(
+      "https://biomart.genenames.org/martservice/results"
+    ) |>
+      httr2::req_url_query(query = q) |>
+      httr2::req_perform() |>
+      .parse_resp_tsv()
+
+    data.table::as.data.table(resp)
+  }
+
+  .cache_fetch(
+    namespace = "biomart/hgnc-query",
+    params = list(
+      genes = genes,
+      attributes = attributes,
+      mart_name = mart_name,
+      dataset_name = dataset_name
+    ),
+    FUN = query_impl
   )
-
-  resp <- httr2::request("https://biomart.genenames.org/martservice/results") |>
-    httr2::req_url_query(query = q) |>
-    httr2::req_perform() |>
-    .parse_resp_tsv()
-
-  data.table::as.data.table(resp)
 }

--- a/R/biomart_core.R
+++ b/R/biomart_core.R
@@ -40,16 +40,14 @@ MartInfo <- R6::R6Class(
     #' @param meta List, additional metadata
     #' @param group Character, the group the mart belongs to
     #' @return A new MartInfo object
-    initialize = function(
-      name,
-      displayName,
-      description,
-      config,
-      isHidden,
-      operation,
-      meta,
-      group
-    ) {
+    initialize = function(name,
+                          displayName,
+                          description,
+                          config,
+                          isHidden,
+                          operation,
+                          meta,
+                          group) {
       self$name <- name
       self$displayName <- displayName
       self$description <- description
@@ -165,14 +163,12 @@ FilterInfo <- R6::R6Class(
     #' @param isHidden Logical, whether the filter should be hidden in UIs
     #' @param values List or vector, possible values for the filter if applicable
     #' @return A new FilterInfo object
-    initialize = function(
-      name,
-      displayName = NULL,
-      description = NULL,
-      type = NULL,
-      isHidden = NULL,
-      values = NULL
-    ) {
+    initialize = function(name,
+                          displayName = NULL,
+                          description = NULL,
+                          type = NULL,
+                          isHidden = NULL,
+                          values = NULL) {
       self$name <- name
       self$displayName <- displayName
       self$description <- description
@@ -230,13 +226,11 @@ AttributeInfo <- R6::R6Class(
     #' @param linkURL Character, URL for additional information about the attribute
     #' @param isHidden Logical, whether the attribute should be hidden in UIs
     #' @return A new AttributeInfo object
-    initialize = function(
-      name,
-      displayName = NULL,
-      description = NULL,
-      linkURL = NULL,
-      isHidden = NULL
-    ) {
+    initialize = function(name,
+                          displayName = NULL,
+                          description = NULL,
+                          linkURL = NULL,
+                          isHidden = NULL) {
       self$name <- name
       self$displayName <- displayName
       self$description <- description

--- a/R/cellosaurus.R
+++ b/R/cellosaurus.R
@@ -132,93 +132,115 @@ mapCell2Accession <- function(
     "hi"
   )
 
-  # create query list
-  .info(funContext, "Creating Cellosaurus queries")
+  query_impl <- function() {
+    # create query list
+    .info(funContext, "Creating Cellosaurus queries")
 
-  queries <- .create_cellosaurus_queries(ids, from, fuzzy)
-  names(queries) <- ids
+    queries <- .create_cellosaurus_queries(ids, from, fuzzy)
+    names(queries) <- ids
 
-  .info(funContext, "Building Cellosaurus requests")
-  # build the list of requests
-  requests <- parallel::mclapply(
-    queries,
-    function(query) {
-      .build_cellosaurus_request(
-        query = query,
-        to = to,
-        numResults = numResults,
-        sort = sort,
-        output = "TXT"
-      )
-    },
-    mc.cores = getOption("annotationgx.mc.cores", getOption("mc.cores", 1L))
-  )
-
-  if (query_only) {
-    return(lapply(requests, function(req) req$url))
-  }
-
-  # Submit requests using parallel httr2 since cellosaurus doesnt throttle
-  .info(funContext, "Performing Cellosaurus queries")
-  responses <- .perform_request_parallel(
-    requests,
-    progress = "Querying Cellosaurus..."
-  )
-  names(responses) <- as.character(ids) # in case its an numeric ID  like cosmic ids
-  if (raw) {
-    return(responses)
-  }
-
-  # parse the responses
-  .info(funContext, "Parsing Cellosaurus responses")
-  responses_dt <- parallel::mclapply(
-    ids,
-    function(name) {
-      resp <- responses[[name]]
-
-      resp <- .parse_cellosaurus_lines(resp)
-      if (length(resp) == 0L) {
-        .warn(paste0("No results found for ", name))
-        result <- data.table::data.table()
-        result$query <- name
-        return(result)
-      }
-      response_dt <- .parse_cellosaurus_text(
-        resp,
-        name,
-        parsed = parsed,
-        keep_duplicates = keep_duplicates
-      )
-      response_dt
-    },
-    mc.cores = getOption("annotationgx.mc.cores", getOption("mc.cores", 1L))
-  )
-
-  responses_dt <- data.table::rbindlist(responses_dt, fill = TRUE)
-
-  if (!include_query) {
-    query_cols <- grep("^query", names(responses_dt), value = TRUE)
-    if (length(query_cols) > 0L) {
-      responses_dt[, (query_cols) := NULL]
-    }
-  }
-
-  core_cols <- c("cellLineName", "accession")
-  existing_core <- core_cols[core_cols %in% names(responses_dt)]
-  if (length(existing_core) > 0L) {
-    query_cols <- if (include_query) {
-      grep("^query", names(responses_dt), value = TRUE)
-    } else {
-      character(0)
-    }
-    extra_cols <- setdiff(names(responses_dt), c(existing_core, query_cols))
-    data.table::setcolorder(
-      responses_dt,
-      c(existing_core, extra_cols, query_cols)
+    .info(funContext, "Building Cellosaurus requests")
+    # build the list of requests
+    requests <- parallel::mclapply(
+      queries,
+      function(query) {
+        .build_cellosaurus_request(
+          query = query,
+          to = to,
+          numResults = numResults,
+          sort = sort,
+          output = "TXT"
+        )
+      },
+      mc.cores = getOption("annotationgx.mc.cores", getOption("mc.cores", 1L))
     )
+
+    if (query_only) {
+      return(lapply(requests, function(req) req$url))
+    }
+
+    # Submit requests using parallel httr2 since cellosaurus doesnt throttle
+    .info(funContext, "Performing Cellosaurus queries")
+    responses <- .perform_request_parallel(
+      requests,
+      progress = "Querying Cellosaurus..."
+    )
+    names(responses) <- as.character(ids) # in case its an numeric ID  like cosmic ids
+    if (raw) {
+      return(responses)
+    }
+
+    # parse the responses
+    .info(funContext, "Parsing Cellosaurus responses")
+    responses_dt <- parallel::mclapply(
+      ids,
+      function(name) {
+        resp <- responses[[name]]
+
+        resp <- .parse_cellosaurus_lines(resp)
+        if (length(resp) == 0L) {
+          .warn(paste0("No results found for ", name))
+          result <- data.table::data.table()
+          result$query <- name
+          return(result)
+        }
+        response_dt <- .parse_cellosaurus_text(
+          resp,
+          name,
+          parsed = parsed,
+          keep_duplicates = keep_duplicates
+        )
+        response_dt
+      },
+      mc.cores = getOption("annotationgx.mc.cores", getOption("mc.cores", 1L))
+    )
+
+    responses_dt <- data.table::rbindlist(responses_dt, fill = TRUE)
+
+    if (!include_query) {
+      query_cols <- grep("^query", names(responses_dt), value = TRUE)
+      if (length(query_cols) > 0L) {
+        responses_dt[, (query_cols) := NULL]
+      }
+    }
+
+    core_cols <- c("cellLineName", "accession")
+    existing_core <- core_cols[core_cols %in% names(responses_dt)]
+    if (length(existing_core) > 0L) {
+      query_cols <- if (include_query) {
+        grep("^query", names(responses_dt), value = TRUE)
+      } else {
+        character(0)
+      }
+      extra_cols <- setdiff(names(responses_dt), c(existing_core, query_cols))
+      data.table::setcolorder(
+        responses_dt,
+        c(existing_core, extra_cols, query_cols)
+      )
+    }
+
+    responses_dt
   }
 
-  return(responses_dt)
+  if (query_only || raw) {
+    return(query_impl())
+  }
+
+  .cache_fetch(
+    namespace = "cellosaurus/map-cell-to-accession",
+    params = list(
+      ids = ids,
+      numResults = numResults,
+      from = from,
+      sort = sort,
+      keep_duplicates = keep_duplicates,
+      fuzzy = fuzzy,
+      parsed = parsed,
+      include_query = include_query,
+      extra = list(...)
+    ),
+    FUN = query_impl
+  )
 }
 
 

--- a/R/cellosaurus_annotations.R
+++ b/R/cellosaurus_annotations.R
@@ -34,40 +34,53 @@ annotateCellAccession <- function(
 ) {
   funContext <- .funContext("annotateCellAccession")
 
-  .info(funContext, "Building Cellosaurus requests...")
-  requests <- parallel::mclapply(accessions, function(accession) {
-    .build_cellosaurus_request(
-      query = accession,
-      to = to,
-      numResults = 1,
-      apiResource = "search/cell-line",
-      output = "TXT",
-      sort = NULL,
-      query_only = FALSE
-    )
-  })
+  query_impl <- function() {
+    .info(funContext, "Building Cellosaurus requests...")
+    requests <- parallel::mclapply(accessions, function(accession) {
+      .build_cellosaurus_request(
+        query = accession,
+        to = to,
+        numResults = 1,
+        apiResource = "search/cell-line",
+        output = "TXT",
+        sort = NULL,
+        query_only = FALSE
+      )
+    })
 
-  .info(funContext, "Performing Requests...")
-  responses <- .perform_request_parallel(
-    requests,
-    progress = "Querying Cellosaurus..."
-  )
-  names(responses) <- accessions
-  if (raw) {
-    return(responses)
+    .info(funContext, "Performing Requests...")
+    responses <- .perform_request_parallel(
+      requests,
+      progress = "Querying Cellosaurus..."
+    )
+    names(responses) <- accessions
+    if (raw) {
+      return(responses)
+    }
+
+    .info(funContext, "Parsing Responses...")
+    responses_dt <- parallel::mclapply(accessions, function(name) {
+      resp <- responses[[name]]
+      .parse_cellosaurus_lines(resp) |>
+        unlist(recursive = FALSE) |>
+        .processEntry() |>
+        .formatSynonyms()
+    })
+    names(responses_dt) <- accessions
+
+    data.table::rbindlist(responses_dt, fill = TRUE)
   }
 
-  .info(funContext, "Parsing Responses...")
-  responses_dt <- parallel::mclapply(accessions, function(name) {
-    resp <- responses[[name]]
-    .parse_cellosaurus_lines(resp) |>
-      unlist(recursive = FALSE) |>
-      .processEntry() |>
-      .formatSynonyms()
-  })
-  names(responses_dt) <- accessions
+  if (query_only || raw) {
+    return(query_impl())
+  }
 
-  responses_dt <- data.table::rbindlist(responses_dt, fill = TRUE)
-
-  return(responses_dt)
+  .cache_fetch(
+    namespace = "cellosaurus/annotate-accession",
+    params = list(
+      accessions = accessions,
+      to = to
+    ),
+    FUN = query_impl
+  )
 }

--- a/R/cellosaurus_helpers.R
+++ b/R/cellosaurus_helpers.R
@@ -241,10 +241,16 @@
 #' @noRd
 .cellosaurus_schema <- function() {
   url <- .buildURL("https://api.cellosaurus.org/openapi.json")
-  request <- .build_request(url)
 
-  resp <- .perform_request(request)
-  .parse_resp_json(resp)
+  .cache_fetch(
+    namespace = "cellosaurus/schema",
+    params = list(url = url),
+    FUN = function() {
+      request <- .build_request(url)
+      resp <- .perform_request(request)
+      .parse_resp_json(resp)
+    }
+  )
 }
 
 

--- a/R/chembl.R
+++ b/R/chembl.R
@@ -64,11 +64,21 @@
 #' @keywords internal
 .build_chembl_request <- function(
   resource,
-  field = NULL, filter_type = NULL, value = NULL, format = "json"
+  field = NULL,
+  filter_type = NULL,
+  value = NULL,
+  format = "json"
 ) {
   # possible formats for now are XML, JSON and YAML
-  checkmate::assert_choice(resource, c(.chembl_resources(), paste0(.chembl_resources(), "/schema")))
-  checkmate::assert_choice(field, getChemblResourceFields(resource), null.ok = TRUE)
+  checkmate::assert_choice(
+    resource,
+    c(.chembl_resources(), paste0(.chembl_resources(), "/schema"))
+  )
+  checkmate::assert_choice(
+    field,
+    getChemblResourceFields(resource),
+    null.ok = TRUE
+  )
   checkmate::assert_choice(filter_type, .chembl_filter_types(), null.ok = TRUE)
   checkmate::assert_character(value, null.ok = TRUE)
   checkmate::assert_choice(format, c("json", "xml", "yaml"))
@@ -105,10 +115,28 @@
 #' queryChemblAPI("mechanism", "molecule_chembl_id", "in", "CHEMBL1413")
 #'
 #' @export
-queryChemblAPI <- function(resource, field, filter_type, value, format = "json") {
-  .build_chembl_request(resource, field, filter_type, value, format) |>
-    .perform_request() |>
-    .parse_resp_json()
+queryChemblAPI <- function(
+  resource,
+  field,
+  filter_type,
+  value,
+  format = "json"
+) {
+  .cache_fetch(
+    namespace = "chembl/query",
+    params = list(
+      resource = resource,
+      field = field,
+      filter_type = filter_type,
+      value = value,
+      format = format
+    ),
+    FUN = function() {
+      .build_chembl_request(resource, field, filter_type, value, format) |>
+        .perform_request() |>
+        .parse_resp_json()
+    }
+  )
 }
 
 
@@ -134,24 +162,42 @@ queryChemblAPI <- function(resource, field, filter_type, value, format = "json")
 #'
 #' @export
 getChemblMechanism <- function(
-  chembl.ID, resources = "mechanism", field = "molecule_chembl_id", filter_type = "in",
-  returnURL = FALSE, raw = FALSE
+  chembl.ID,
+  resources = "mechanism",
+  field = "molecule_chembl_id",
+  filter_type = "in",
+  returnURL = FALSE,
+  raw = FALSE
 ) {
   funContext <- .funContext("getChemblMechanism")
   # constructChemblQuery(resource = "mechanism", field = "molecule_chembl_id", filter_type = "in", value = "CHEMBL1413")
   # urls <- constructChemblQuery(resource = resources, field = field, filter_type = filter_type, value = chembl.ID)
   # urls <- URLencode(urls)
 
-  .info(funContext, "Retrieving ChEMBL Mechanism information for ", length(chembl.ID), " ChEMBL IDs.")
+  .info(
+    funContext,
+    "Retrieving ChEMBL Mechanism information for ",
+    length(chembl.ID),
+    " ChEMBL IDs."
+  )
   response_dts <- lapply(chembl.ID, function(chembl.ID) {
-    request <- .build_chembl_request(resource = resources, field = field, filter_type = filter_type, value = chembl.ID)
+    request <- .build_chembl_request(
+      resource = resources,
+      field = field,
+      filter_type = filter_type,
+      value = chembl.ID
+    )
 
     if (returnURL) {
       return(request$url)
     }
-    response <- .perform_request(request)
 
-    response_json <- .parse_resp_json(response)
+    response_json <- queryChemblAPI(
+      resource = resources,
+      field = field,
+      filter_type = filter_type,
+      value = chembl.ID
+    )
     if (raw) {
       return(response_json)
     }

--- a/R/chembl_helpers.R
+++ b/R/chembl_helpers.R
@@ -3,12 +3,38 @@
 #' @noRd
 .chembl_resources <- function() {
   c(
-    "activity", "assay", "atc_class", "binding_site", "biotherapeutic", "cell_line",
-    "chembl_id_lookup", "compound_record", "compound_structural_alert", "document",
-    "document_similarity", "document_term", "drug", "drug_indication", "drug_warning",
-    "go_slim", "image", "mechanism", "metabolism", "molecule", "molecule_form",
-    "organism", "protein_classification", "similarity", "source", "status", "substructure",
-    "target", "target_component", "target_relation", "tissue", "xref_source"
+    "activity",
+    "assay",
+    "atc_class",
+    "binding_site",
+    "biotherapeutic",
+    "cell_line",
+    "chembl_id_lookup",
+    "compound_record",
+    "compound_structural_alert",
+    "document",
+    "document_similarity",
+    "document_term",
+    "drug",
+    "drug_indication",
+    "drug_warning",
+    "go_slim",
+    "image",
+    "mechanism",
+    "metabolism",
+    "molecule",
+    "molecule_form",
+    "organism",
+    "protein_classification",
+    "similarity",
+    "source",
+    "status",
+    "substructure",
+    "target",
+    "target_component",
+    "target_relation",
+    "tissue",
+    "xref_source"
   )
 }
 
@@ -17,9 +43,25 @@
 #' @noRd
 .chembl_filter_types <- function() {
   c(
-    "exact", "iexact", "contains", "icontains", "startswith", "istartswith",
-    "endswith", "iendswith", "regex", "iregex", "gt", "gte", "lt", "lte",
-    "range", "in", "isnull", "search", "only"
+    "exact",
+    "iexact",
+    "contains",
+    "icontains",
+    "startswith",
+    "istartswith",
+    "endswith",
+    "iendswith",
+    "regex",
+    "iregex",
+    "gt",
+    "gte",
+    "lt",
+    "lte",
+    "range",
+    "in",
+    "isnull",
+    "search",
+    "only"
   )
 }
 
@@ -28,11 +70,23 @@
 #' @noRd
 .chembl_mechanism_cols <- function() {
   c(
-    "action_type", "binding_site_comment", "direct_interaction", "disease_efficacy",
-    "max_phase", "mec_id", "mechanism_comment", "mechanism_of_action",
-    "mechanism_refs", "molecular_mechanism", "molecule_chembl_id",
-    "parent_molecule_chembl_id", "record_id", "selectivity_comment",
-    "site_id", "target_chembl_id", "variant_sequence"
+    "action_type",
+    "binding_site_comment",
+    "direct_interaction",
+    "disease_efficacy",
+    "max_phase",
+    "mec_id",
+    "mechanism_comment",
+    "mechanism_of_action",
+    "mechanism_refs",
+    "molecular_mechanism",
+    "molecule_chembl_id",
+    "parent_molecule_chembl_id",
+    "record_id",
+    "selectivity_comment",
+    "site_id",
+    "target_chembl_id",
+    "variant_sequence"
   )
 }
 
@@ -40,7 +94,13 @@
 #' @keywords internal
 #' @noRd
 .chembl_resource_schema <- function(resource) {
-  .build_chembl_request(paste0(resource, "/schema")) |>
-    .perform_request() |>
-    .parse_resp_json()
+  .cache_fetch(
+    namespace = "chembl/schema",
+    params = list(resource = resource),
+    FUN = function() {
+      .build_chembl_request(paste0(resource, "/schema")) |>
+        .perform_request() |>
+        .parse_resp_json()
+    }
+  )
 }

--- a/R/oncotree.R
+++ b/R/oncotree.R
@@ -14,11 +14,18 @@
 ) {
   url <- "http://oncotree.mskcc.org"
   targetClean <- match.arg(target)
-  .buildURL(url, "api", targetClean) |>
-    .build_request() |>
-    .perform_request() |>
-    .parse_resp_json() |>
-    .asDT()
+
+  .cache_fetch(
+    namespace = "oncotree/reference",
+    params = list(target = targetClean, base_url = url),
+    FUN = function() {
+      .buildURL(url, "api", targetClean) |>
+        .build_request() |>
+        .perform_request() |>
+        .parse_resp_json() |>
+        .asDT()
+    }
+  )
 }
 #' Get available Oncotree versions
 #'

--- a/R/pubchem_rest.R
+++ b/R/pubchem_rest.R
@@ -30,91 +30,112 @@ getPubchemCompound <- function(
   ...
 ) {
   funContext <- .funContext("getPubchemCompound")
-  to_ <- if (to == "property") {
-    checkmate::assert_atomic(properties, all.missing = FALSE)
-    checkmate::assert_character(properties)
-    to <- paste0(to, "/", paste0(properties, collapse = ","))
-  } else {
-    to
-  }
-
-  .info(funContext, "Building PubChem REST queries...")
-  requests <- lapply(ids, function(x) {
-    .build_pubchem_rest_query(
-      id = x,
-      domain = "compound",
-      namespace = from,
-      operation = to_,
-      output = output,
-      raw = raw,
-      query_only = query_only,
-      ...
-    )
-  })
-  if (query_only) {
-    return(requests)
-  }
-
-  tryCatch(
-    {
-      .info(funContext, "Retrieving compound information...")
-      resps_raw <- httr2::req_perform_sequential(
-        requests,
-        on_error = "continue",
-        progress = "Querying PubCHEM REST API...."
-      )
-      names(resps_raw) <- ids
-    },
-    error = function(e) {
-      .err(
-        funContext,
-        " An error occurred while retrieving the compound information:\n",
-        e
-      )
+  query_impl <- function() {
+    response_name <- to
+    operation <- if (to == "property") {
+      checkmate::assert_atomic(properties, all.missing = FALSE)
+      checkmate::assert_character(properties)
+      response_name <- paste0(to, "/", paste0(properties, collapse = ","))
+      response_name
+    } else {
+      to
     }
-  )
 
-  .debug(funContext, " Number of responses: ", length(resps_raw))
-  if (raw) {
-    return(resps_raw)
-  }
-
-  # Parse the responses
-  .info(funContext, "Parsing PubChem REST responses...")
-  resps <- .parse_pubchem_rest_responses(resps_raw)
-
-  # filter failed
-  # if any query failed, return the failed queries as attributes
-  failed <- vapply(
-    resps_raw,
-    httr2::resp_is_error,
-    FUN.VALUE = logical(1),
-    USE.NAMES = TRUE
-  )
-  if (any(failed)) {
-    .warn(
-      funContext,
-      " Some queries failed. See the 'failed' object for details."
-    )
-    failures <- lapply(resps_raw[failed], function(resp) {
-      .parse_resp_json(resp)$Fault
+    .info(funContext, "Building PubChem REST queries...")
+    requests <- lapply(ids, function(x) {
+      .build_pubchem_rest_query(
+        id = x,
+        domain = "compound",
+        namespace = from,
+        operation = operation,
+        output = output,
+        raw = raw,
+        query_only = query_only,
+        ...
+      )
     })
-  } else {
-    failures <- NULL
+    if (query_only) {
+      return(requests)
+    }
+
+    tryCatch(
+      {
+        .info(funContext, "Retrieving compound information...")
+        resps_raw <- httr2::req_perform_sequential(
+          requests,
+          on_error = "continue",
+          progress = "Querying PubCHEM REST API...."
+        )
+        names(resps_raw) <- ids
+      },
+      error = function(e) {
+        .err(
+          funContext,
+          " An error occurred while retrieving the compound information:\n",
+          e
+        )
+      }
+    )
+
+    .debug(funContext, " Number of responses: ", length(resps_raw))
+    if (raw) {
+      return(resps_raw)
+    }
+
+    # Parse the responses
+    .info(funContext, "Parsing PubChem REST responses...")
+    resps <- .parse_pubchem_rest_responses(resps_raw)
+
+    # filter failed
+    # if any query failed, return the failed queries as attributes
+    failed <- vapply(
+      resps_raw,
+      httr2::resp_is_error,
+      FUN.VALUE = logical(1),
+      USE.NAMES = TRUE
+    )
+    if (any(failed)) {
+      .warn(
+        funContext,
+        " Some queries failed. See the 'failed' object for details."
+      )
+      failures <- lapply(resps_raw[failed], function(resp) {
+        .parse_resp_json(resp)$Fault
+      })
+    } else {
+      failures <- NULL
+    }
+
+    # Combine the responses
+    # might be able to just do the else part...
+    if (from != "name") {
+      responses <- data.table::rbindlist(resps, fill = TRUE)
+    } else {
+      responses <- data.table::rbindlist(resps, idcol = from, fill = TRUE)
+    }
+    data.table::setnames(responses, "V1", response_name, skip_absent = TRUE)
+
+    attributes(responses)$failed <- failures
+
+    responses
   }
 
-  # Combine the responses
-  # might be able to just do the else part...
-  if (from != "name") {
-    responses <- data.table::rbindlist(resps, fill = TRUE)
-  } else {
-    responses <- data.table::rbindlist(resps, idcol = from, fill = TRUE)
+  if (query_only || raw) {
+    return(query_impl())
   }
-  data.table::setnames(responses, "V1", to, skip_absent = TRUE)
 
-  attributes(responses)$failed <- failures
-
-  return(responses)
+  .cache_fetch(
+    namespace = "pubchem/compound-query",
+    params = list(
+      ids = ids,
+      from = from,
+      to = to,
+      properties = properties,
+      output = output,
+      extra = list(...)
+    ),
+    FUN = query_impl
+  )
 }
 
 
@@ -197,21 +218,30 @@ mapCID2Properties <- function(
 #' @export
 getPubchemProperties <- function() {
   url <- "https://pubchem.ncbi.nlm.nih.gov/pug_rest/pug_rest.xsd"
-  response <- .build_request(url) |>
-    .perform_request()
 
-  node_list <- xml2::read_xml(response$body) |>
-    xml2::xml_children() |>
-    xml2::as_list()
+  .cache_fetch(
+    namespace = "pubchem/properties",
+    params = list(url = url),
+    FUN = function() {
+      response <- .build_request(url) |>
+        .perform_request()
 
-  properties <- node_list[[3]]$complexType$sequence$element$complexType$sequence
+      node_list <- xml2::read_xml(response$body) |>
+        xml2::xml_children() |>
+        xml2::as_list()
 
-  lapply(properties, function(x) {
-    list(
-      name = attr(x, "name"),
-      type = gsub("xs:", "", attr(x, "type"))
-    ) |>
-      .asDT()
-  }) |>
-    data.table::rbindlist()
+      properties <- node_list[[
+        3
+      ]]$complexType$sequence$element$complexType$sequence
+
+      lapply(properties, function(x) {
+        list(
+          name = attr(x, "name"),
+          type = gsub("xs:", "", attr(x, "type"))
+        ) |>
+          .asDT()
+      }) |>
+        data.table::rbindlist()
+    }
+  )
 }

--- a/R/pubchem_view.R
+++ b/R/pubchem_view.R
@@ -89,102 +89,130 @@ annotatePubchemCompound <- function(
   nParallel = 1
 ) {
   funContext <- .funContext("annotatePubchemCompound")
-
-  .info(funContext, sprintf("Building requests for %s CIDs", length(cids)))
-  requests <- lapply(cids, function(cid) {
-    .build_pubchem_view_query(
-      id = cid,
-      record = "compound",
-      heading = heading,
-      output = "JSON",
-      source = source
-    )
-  })
-
-  .debug(
-    funContext,
-    paste0(
-      "query: ",
-      vapply(requests, `[[`, FUN.VALUE = character(1), i = "url")
-    )
+  cacheable_headings <- c(
+    "ChEMBL ID",
+    "CAS",
+    "NSC Number",
+    "ATC Code",
+    "Drug Induced Liver Injury"
   )
-  if (query_only) {
-    return(requests)
-  }
 
-  tryCatch(
-    {
-      resp_raw <- httr2::req_perform_sequential(
-        reqs = requests,
-        on_error = "continue",
-        progress = "Performing API requests..."
+  query_impl <- function() {
+    .info(funContext, sprintf("Building requests for %s CIDs", length(cids)))
+    requests <- lapply(cids, function(cid) {
+      .build_pubchem_view_query(
+        id = cid,
+        record = "compound",
+        heading = heading,
+        output = "JSON",
+        source = source
       )
-    },
-    error = function(e) {
-      .err(funContext, "An error occurred while performing requests:\n", e)
-    }
-  )
+    })
 
-  if (raw) {
-    return(resp_raw)
-  }
-
-  responses <- lapply(seq_along(resp_raw), function(i) {
-    resp <- resp_raw[[i]]
-    if (is.null(resp)) {
-      return(NA_character_)
+    .debug(
+      funContext,
+      paste0(
+        "query: ",
+        vapply(requests, `[[`, FUN.VALUE = character(1), i = "url")
+      )
+    )
+    if (query_only) {
+      return(requests)
     }
+
     tryCatch(
       {
-        .parse_resp_json(resp)
+        resp_raw <- httr2::req_perform_sequential(
+          reqs = requests,
+          on_error = "continue",
+          progress = "Performing API requests..."
+        )
       },
       error = function(e) {
-        warnmsg <- sprintf(
-          "\nThe response could not be parsed:\n\t%s\tReturning NA instead for CID: %s for the heading: %s",
-          e,
-          cids[i],
-          heading
-        )
-        .warn(
-          funContext,
-          warnmsg
-        )
-        resp
+        .err(funContext, "An error occurred while performing requests:\n", e)
       }
     )
-  })
 
-  # apply the parse function to each response depending on heading
-  parsed_responses <- parallel::mclapply(
-    responses,
-    function(response) {
-      switch(heading,
-        "ChEMBL ID" = .parseCHEMBLresponse(response),
-        "CAS" = .parseCASresponse(response),
-        "NSC Number" = .parseNSCresponse(response),
-        "ATC Code" = .parseATCresponse(response),
-        "Drug Induced Liver Injury" = .parseDILIresponse(response),
-        tryCatch(
-          {
-            parse_function(response)
-          },
-          error = function(e) {
-            .warn(
-              funContext,
-              "The parseFUN function failed: ",
-              e,
-              ". Returning unparsed results instead. Please test the parseFUN
-                  on the returned data."
-            )
-            response
-          }
-        )
+    if (raw) {
+      return(resp_raw)
+    }
+
+    responses <- lapply(seq_along(resp_raw), function(i) {
+      resp <- resp_raw[[i]]
+      if (is.null(resp)) {
+        return(NA_character_)
+      }
+      tryCatch(
+        {
+          .parse_resp_json(resp)
+        },
+        error = function(e) {
+          warnmsg <- sprintf(
+            "\nThe response could not be parsed:\n\t%s\tReturning NA instead for CID: %s for the heading: %s",
+            e,
+            cids[i],
+            heading
+          )
+          .warn(
+            funContext,
+            warnmsg
+          )
+          resp
+        }
       )
-    },
-    mc.cores = nParallel
-  )
+    })
 
-  sapply(parsed_responses, .replace_null)
+    # apply the parse function to each response depending on heading
+    parsed_responses <- parallel::mclapply(
+      responses,
+      function(response) {
+        switch(
+          heading,
+          "ChEMBL ID" = .parseCHEMBLresponse(response),
+          "CAS" = .parseCASresponse(response),
+          "NSC Number" = .parseNSCresponse(response),
+          "ATC Code" = .parseATCresponse(response),
+          "Drug Induced Liver Injury" = .parseDILIresponse(response),
+          tryCatch(
+            {
+              parse_function(response)
+            },
+            error = function(e) {
+              .warn(
+                funContext,
+                "The parseFUN function failed: ",
+                e,
+                ". Returning unparsed results instead. Please test the parseFUN
+                    on the returned data."
+              )
+              response
+            }
+          )
+        )
+      },
+      mc.cores = nParallel
+    )
+
+    sapply(parsed_responses, .replace_null)
+  }
+
+  cacheable <- !query_only &&
+    !raw &&
+    (heading %in% cacheable_headings || identical(parse_function, identity))
+
+  if (!cacheable) {
+    return(query_impl())
+  }
+
+  .cache_fetch(
+    namespace = "pubchem/view-annotation",
+    params = list(
+      cids = cids,
+      heading = heading,
+      source = source
+    ),
+    FUN = query_impl
+  )
 }
 
 # helper function to replace NULL with NA

--- a/R/pubchem_view.R
+++ b/R/pubchem_view.R
@@ -166,8 +166,7 @@ annotatePubchemCompound <- function(
     parsed_responses <- parallel::mclapply(
       responses,
       function(response) {
-        switch(
-          heading,
+        switch(heading,
           "ChEMBL ID" = .parseCHEMBLresponse(response),
           "CAS" = .parseCASresponse(response),
           "NSC Number" = .parseNSCresponse(response),

--- a/R/pubchem_view_helpers.R
+++ b/R/pubchem_view_helpers.R
@@ -7,9 +7,17 @@
 #' @noRd
 .get_all_heading_types_base <- function() {
   url <- "https://pubchem.ncbi.nlm.nih.gov/rest/pug/annotations/headings/JSON"
-  req <- .build_pubchem_request(url)
-  response <- httr2::req_perform(req) |> .parse_resp_json()
-  .asDT(response[[1]][[1]])
+
+  .cache_fetch(
+    namespace = "pubchem/annotation-headings",
+    params = list(url = url),
+    FUN = function() {
+      req <- .build_pubchem_request(url)
+      response <- httr2::req_perform(req) |>
+        .parse_resp_json()
+      .asDT(response[[1]][[1]])
+    }
+  )
 }
 
 #' @keywords internal

--- a/R/unichem.R
+++ b/R/unichem.R
@@ -32,77 +32,83 @@
 #' @export
 getUnichemSources <- function(all_columns = FALSE) {
   funContext <- .funContext("AnnotationGx::getUnichemSources")
-  request <- .build_unichem_query("sources") |>
-    .build_request()
-  response <- request |>
-    .perform_request() |>
-    .parse_unichem_response(
-      request_label = "UniChem sources",
-      request = request
-    )
+  sources_dt <- .cache_fetch(
+    namespace = "unichem/sources",
+    params = list(all_columns = TRUE),
+    FUN = function() {
+      request <- .build_unichem_query("sources") |>
+        .build_request()
+      response <- request |>
+        .perform_request() |>
+        .parse_unichem_response(
+          request_label = "UniChem sources",
+          request = request
+        )
 
-  if (response$response != "Success") {
-    .err(funContext, "Unichem API request failed.")
-  }
+      if (response$response != "Success") {
+        .err(funContext, "Unichem API request failed.")
+      }
 
-  .debug(
-    funContext,
-    sprintf("Unichem sourceCount: %s", response$totalSources)
+      .debug(
+        funContext,
+        sprintf("Unichem sourceCount: %s", response$totalSources)
+      )
+
+      sources_dt <- .asDT(response$sources)
+
+      old_names <- c(
+        "UCICount",
+        "baseIdUrl",
+        "description",
+        "lastUpdated",
+        "name",
+        "nameLabel",
+        "nameLong",
+        "sourceID",
+        "srcDetails",
+        "srcReleaseDate",
+        "srcReleaseNumber",
+        "srcUrl",
+        "updateComments"
+      )
+
+      new_names <- c(
+        "CompoundCount",
+        "BaseURL",
+        "Description",
+        "LastUpdated",
+        "Name",
+        "NameLabel",
+        "NameLong",
+        "SourceID",
+        "Details",
+        "ReleaseDate",
+        "ReleaseNumber",
+        "URL",
+        "UpdateComments"
+      )
+
+      data.table::setnames(sources_dt, old_names, new_names)
+
+      new_order <- c(
+        "Name",
+        "NameLabel",
+        "NameLong",
+        "SourceID",
+        "CompoundCount",
+        "BaseURL",
+        "URL",
+        "Details",
+        "Description",
+        "ReleaseNumber",
+        "ReleaseDate",
+        "LastUpdated",
+        "UpdateComments"
+      )
+
+      sources_dt[, new_order, with = FALSE]
+    }
   )
-
-  sources_dt <- .asDT(response$sources)
-
-  old_names <- c(
-    "UCICount",
-    "baseIdUrl",
-    "description",
-    "lastUpdated",
-    "name",
-    "nameLabel",
-    "nameLong",
-    "sourceID",
-    "srcDetails",
-    "srcReleaseDate",
-    "srcReleaseNumber",
-    "srcUrl",
-    "updateComments"
-  )
-
-  new_names <- c(
-    "CompoundCount",
-    "BaseURL",
-    "Description",
-    "LastUpdated",
-    "Name",
-    "NameLabel",
-    "NameLong",
-    "SourceID",
-    "Details",
-    "ReleaseDate",
-    "ReleaseNumber",
-    "URL",
-    "UpdateComments"
-  )
-
-  data.table::setnames(sources_dt, old_names, new_names)
-
-  new_order <- c(
-    "Name",
-    "NameLabel",
-    "NameLong",
-    "SourceID",
-    "CompoundCount",
-    "BaseURL",
-    "URL",
-    "Details",
-    "Description",
-    "ReleaseNumber",
-    "ReleaseDate",
-    "LastUpdated",
-    "UpdateComments"
-  )
-
-  sources_dt <- sources_dt[, new_order, with = FALSE]
 
   if (all_columns) {
     return(sources_dt)
@@ -261,8 +267,6 @@ queryUnichemCompound <- function(
     src_ids
   }
 
-  source_ids <- validate_source_ids(sourceID)
-
   build_request <- function(cmp, src) {
     .build_unichem_compound_req(
       type = type,
@@ -317,77 +321,98 @@ queryUnichemCompound <- function(
     )
   }
 
-  if (many_queries) {
-    requests <- Map(build_request, compounds, source_ids)
-    name_candidates <- names(compounds)
-    if (
-      !is.null(name_candidates) && length(name_candidates) == length(compounds)
-    ) {
-      names(requests) <- name_candidates
-    } else {
-      names(requests) <- as.character(compounds)
+  query_impl <- function() {
+    source_ids <- validate_source_ids(sourceID)
+
+    if (many_queries) {
+      requests <- Map(build_request, compounds, source_ids)
+      name_candidates <- names(compounds)
+      if (
+        !is.null(name_candidates) &&
+          length(name_candidates) == length(compounds)
+      ) {
+        names(requests) <- name_candidates
+      } else {
+        names(requests) <- as.character(compounds)
+      }
+
+      if (request_only) {
+        return(requests)
+      }
+
+      responses <- .perform_request_parallel(requests, progress = progress)
+      names(responses) <- names(requests)
+
+      parsed_responses <- Map(
+        function(response, request, cmp_label) {
+          .parse_unichem_response(
+            response,
+            paste0("compound `", cmp_label, "` with type `", type, "`"),
+            request = request
+          )
+        },
+        responses,
+        requests,
+        names(responses)
+      )
+
+      if (raw) {
+        names(parsed_responses) <- names(responses)
+        return(parsed_responses)
+      }
+
+      results <- Map(
+        function(parsed, cmp_label) {
+          tryCatch(
+            parse_response(parsed, cmp_label),
+            error = function(e) {
+              structure(
+                list(error = conditionMessage(e)),
+                class = c("unichem_error", "list")
+              )
+            }
+          )
+        },
+        parsed_responses,
+        names(responses)
+      )
+
+      names(results) <- names(responses)
+      return(results)
     }
 
+    request <- build_request(compounds[[1L]], source_ids[[1L]])
     if (request_only) {
-      return(requests)
+      return(request)
     }
 
-    responses <- .perform_request_parallel(requests, progress = progress)
-    names(responses) <- names(requests)
-
-    parsed_responses <- Map(
-      function(response, request, cmp_label) {
-        .parse_unichem_response(
-          response,
-          paste0("compound `", cmp_label, "` with type `", type, "`"),
-          request = request
-        )
-      },
-      responses,
-      requests,
-      names(responses)
+    response <- request |>
+      .perform_request()
+    parsed <- .parse_unichem_response(
+      response,
+      paste0("compound `", compounds[[1L]], "` with type `", type, "`"),
+      request = request
     )
 
     if (raw) {
-      names(parsed_responses) <- names(responses)
-      return(parsed_responses)
+      return(parsed)
     }
 
-    results <- Map(
-      function(parsed, cmp_label) {
-        tryCatch(
-          parse_response(parsed, cmp_label),
-          error = function(e) {
-            structure(
-              list(error = conditionMessage(e)),
-              class = c("unichem_error", "list")
-            )
-          }
-        )
-      },
-      parsed_responses,
-      names(responses)
-    )
-
-    names(results) <- names(responses)
-    return(results)
+    parse_response(parsed, compounds[[1L]])
   }
 
-  request <- build_request(compounds[[1L]], source_ids[[1L]])
-  if (request_only) {
-    return(request)
+  if (request_only || raw) {
+    return(query_impl())
   }
 
-  response <- request |> .perform_request()
-  parsed <- .parse_unichem_response(
-    response,
-    paste0("compound `", compounds[[1L]], "` with type `", type, "`"),
-    request = request
+  .cache_fetch(
+    namespace = "unichem/query",
+    params = list(
+      compound = compounds,
+      type = type,
+      sourceID = sourceID,
+      extra = list(...)
+    ),
+    FUN = query_impl
   )
-
-  if (raw) {
-    return(parsed)
-  }
-
-  parse_response(parsed, compounds[[1L]])
 }

--- a/R/utils-cache.R
+++ b/R/utils-cache.R
@@ -1,0 +1,216 @@
+#' Get the package cache directory.
+#'
+#' @return Character(1) path to the AnnotationGx cache directory.
+#' @keywords internal
+#' @noRd
+.annotationgx_cache_dir <- function() {
+  cache_dir <- getOption("annotationgx.cache.dir")
+
+  if (is.null(cache_dir) || length(cache_dir) != 1L || !nzchar(cache_dir)) {
+    cache_dir <- tools::R_user_dir("AnnotationGx", which = "cache")
+  }
+
+  dir.create(cache_dir, recursive = TRUE, showWarnings = FALSE)
+  cache_dir
+}
+
+
+#' Get the package cache handle.
+#'
+#' @return A `BiocFileCache` object.
+#' @keywords internal
+#' @noRd
+.annotationgx_cache <- function() {
+  BiocFileCache::BiocFileCache(.annotationgx_cache_dir(), ask = FALSE)
+}
+
+
+#' Check whether persistent caching is enabled.
+#'
+#' @return Logical(1) indicating whether persistent caching is enabled.
+#' @keywords internal
+#' @noRd
+.cache_enabled <- function() {
+  isTRUE(getOption("annotationgx.cache.use", TRUE))
+}
+
+
+#' Check whether cached values should be refreshed.
+#'
+#' @return Logical(1) indicating whether cache refresh is enabled.
+#' @keywords internal
+#' @noRd
+.cache_refresh_enabled <- function() {
+  isTRUE(getOption("annotationgx.cache.refresh", FALSE))
+}
+
+
+#' Hash cache inputs into a stable key fragment.
+#'
+#' @param x Arbitrary R object.
+#' @return Character(1) hash string.
+#' @keywords internal
+#' @noRd
+.cache_hash <- function(x) {
+  tmp <- tempfile(fileext = ".rds")
+  on.exit(unlink(tmp), add = TRUE)
+
+  saveRDS(x, file = tmp, version = 2)
+  unname(tools::md5sum(tmp))
+}
+
+
+#' Build a cache key.
+#'
+#' @param namespace Character(1) namespace for the cached value.
+#' @param params List of inputs describing the cached value.
+#' @return Character(1) cache key.
+#' @keywords internal
+#' @noRd
+.cache_key <- function(namespace, params = list()) {
+  paste(
+    "AnnotationGx",
+    as.character(utils::packageVersion("AnnotationGx")),
+    namespace,
+    .cache_hash(params),
+    sep = "/"
+  )
+}
+
+
+#' Look up a cache record identifier.
+#'
+#' @param bfc A `BiocFileCache` object.
+#' @param key Character(1) cache key.
+#' @return Character(1) cache record id or `NULL`.
+#' @keywords internal
+#' @noRd
+.cache_rid <- function(bfc, key) {
+  hits <- BiocFileCache::bfcquery(
+    bfc,
+    key,
+    field = "rname",
+    exact = TRUE
+  )
+
+  if (nrow(hits) == 0L) {
+    return(NULL)
+  }
+
+  hits$rid[[1L]]
+}
+
+
+#' Read a cached R object if present.
+#'
+#' @param key Character(1) cache key.
+#' @return Cached object or `NULL` if unavailable.
+#' @keywords internal
+#' @noRd
+.cache_read <- function(key) {
+  if (!.cache_enabled()) {
+    return(NULL)
+  }
+
+  tryCatch(
+    {
+      bfc <- .annotationgx_cache()
+      rid <- .cache_rid(bfc, key)
+
+      if (is.null(rid)) {
+        return(NULL)
+      }
+
+      path <- BiocFileCache::bfcrpath(bfc, rids = rid)
+      if (!file.exists(path)) {
+        return(NULL)
+      }
+
+      readRDS(path)
+    },
+    error = function(e) {
+      .debug(
+        .funContext("AnnotationGx:::.cache_read"),
+        "Cache read failed for key `",
+        key,
+        "`: ",
+        conditionMessage(e)
+      )
+      NULL
+    }
+  )
+}
+
+
+#' Write an R object to the package cache.
+#'
+#' @param key Character(1) cache key.
+#' @param value Arbitrary R object to cache.
+#' @return Invisibly returns `value`.
+#' @keywords internal
+#' @noRd
+.cache_write <- function(key, value) {
+  if (!.cache_enabled()) {
+    return(invisible(value))
+  }
+
+  tryCatch(
+    {
+      bfc <- .annotationgx_cache()
+      rid <- .cache_rid(bfc, key)
+
+      path <- if (is.null(rid)) {
+        unname(BiocFileCache::bfcnew(bfc, rname = key, ext = ".rds"))
+      } else {
+        BiocFileCache::bfcrpath(bfc, rids = rid)
+      }
+
+      saveRDS(value, file = path, version = 2)
+      invisible(value)
+    },
+    error = function(e) {
+      .debug(
+        .funContext("AnnotationGx:::.cache_write"),
+        "Cache write failed for key `",
+        key,
+        "`: ",
+        conditionMessage(e)
+      )
+      invisible(value)
+    }
+  )
+}
+
+
+#' Fetch a value from cache or compute and persist it.
+#'
+#' @param namespace Character(1) cache namespace.
+#' @param params List of cache inputs.
+#' @param FUN Function used to compute the value when there is a cache miss.
+#' @param refresh Logical(1) indicating whether to force recomputation.
+#' @return Cached or computed value.
+#' @keywords internal
+#' @noRd
+.cache_fetch <- function(
+  namespace,
+  params = list(),
+  FUN,
+  refresh = .cache_refresh_enabled()
+) {
+  if (!.cache_enabled()) {
+    return(FUN())
+  }
+
+  key <- .cache_key(namespace, params)
+
+  if (!isTRUE(refresh)) {
+    cached <- .cache_read(key)
+    if (!is.null(cached)) {
+      return(cached)
+    }
+  }
+
+  value <- FUN()
+  .cache_write(key, value)
+  value
+}

--- a/tests/testthat/setup-cache.R
+++ b/tests/testthat/setup-cache.R
@@ -1,0 +1,9 @@
+cache_dir <- file.path(tempdir(), "AnnotationGx-test-cache")
+unlink(cache_dir, recursive = TRUE, force = TRUE)
+dir.create(cache_dir, recursive = TRUE, showWarnings = FALSE)
+
+options(
+  annotationgx.cache.dir = cache_dir,
+  annotationgx.cache.refresh = FALSE,
+  annotationgx.cache.use = TRUE
+)

--- a/tests/testthat/test_cache_helpers.R
+++ b/tests/testthat/test_cache_helpers.R
@@ -1,0 +1,59 @@
+library(AnnotationGx)
+library(testthat)
+
+test_that(".cache_fetch persists values across calls", {
+  counter <- 0L
+
+  first <- .cache_fetch(
+    namespace = "tests/cache-persist",
+    params = list(id = "persist"),
+    FUN = function() {
+      counter <<- counter + 1L
+      list(value = counter)
+    }
+  )
+
+  second <- .cache_fetch(
+    namespace = "tests/cache-persist",
+    params = list(id = "persist"),
+    FUN = function() {
+      counter <<- counter + 1L
+      list(value = counter)
+    }
+  )
+
+  expect_equal(counter, 1L)
+  expect_equal(first, second)
+  expect_equal(first$value, 1L)
+})
+
+
+test_that(".cache_fetch respects the refresh option", {
+  old_refresh <- getOption("annotationgx.cache.refresh")
+  on.exit(options(annotationgx.cache.refresh = old_refresh), add = TRUE)
+
+  options(annotationgx.cache.refresh = TRUE)
+
+  counter <- 0L
+
+  first <- .cache_fetch(
+    namespace = "tests/cache-refresh",
+    params = list(id = "refresh"),
+    FUN = function() {
+      counter <<- counter + 1L
+      counter
+    }
+  )
+
+  second <- .cache_fetch(
+    namespace = "tests/cache-refresh",
+    params = list(id = "refresh"),
+    FUN = function() {
+      counter <<- counter + 1L
+      counter
+    }
+  )
+
+  expect_equal(first, 1L)
+  expect_equal(second, 2L)
+})


### PR DESCRIPTION
## what changed
- add a package-level `BiocFileCache` layer with deterministic cache keys
- persist remote metadata for Cellosaurus, PubChem, ChEMBL, UniChem, OncoTree, and BioMart
- cache parsed API query results for Cellosaurus, PubChem, ChEMBL, UniChem, and HGNC BioMart where `raw` and `query_only` are not requested
- isolate test runs in a temporary AnnotationGx cache directory and add cache helper coverage
- bump the package version to `0.99.7` and record the change in `NEWS.md`

## why it changed
- the package makes repeated remote requests against APIs that are slow, rate-limited, or transiently unavailable
- persistent caching reduces redundant traffic, improves repeat-call latency, and gives the package a legitimate Bioconductor infrastructure dependency

## impact
- repeated metadata lookups and parsed query calls now reuse cached results across R sessions by default
- low-level `raw` and `query_only` workflows still bypass the persistent cache
- tests no longer touch a user cache directory during package checks

## validation
- parsed `NEWS.md` with `tools:::.build_news_db_from_package_NEWS_md()`
- ran the full `tests/testthat` suite file-by-file under `load_all()` with an isolated temp cache